### PR TITLE
Add modular LLM service with OpenAI implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,24 @@ recommended tools as part of a tool execution chain.
 - `src/controllers/` – controller logic (request handlers)
 - `src/services/` – business logic (future LLM and tool integration)
 
+## LLM Integration
+
+The service communicates with large language models via pluggable providers.
+Select the provider using the `LLM_PROVIDER` environment variable (defaults to
+`openai`). For OpenAI you must also provide `OPENAI_API_KEY`.
+
+### LLM Endpoint
+
+- `POST /llm` – send a prompt and receive the generated response.
+  ```json
+  {
+    "prompt": "Hello",
+    "options": { "model": "gpt-3.5-turbo" }
+  }
+  ```
+
+The response streams the generated text chunks as plain text. Clients should
+consume the body incrementally until the connection closes.
+
 The project uses [Express](https://expressjs.com/) and [Nodemon](https://www.npmjs.com/package/nodemon)
 for development.

--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const healthRouter = require('./routes/health');
+const llmRouter = require('./routes/llm');
 
 const app = express();
 
 app.use(express.json());
 app.use('/health', healthRouter);
+app.use('/llm', llmRouter);
 
 module.exports = app;

--- a/src/controllers/llmController.js
+++ b/src/controllers/llmController.js
@@ -1,0 +1,22 @@
+const { createLLMService } = require('../services');
+
+const llmService = createLLMService();
+
+exports.generate = async (req, res) => {
+  const { prompt, options } = req.body;
+  if (!prompt) {
+    return res.status(400).json({ error: 'Prompt is required' });
+  }
+
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+
+  try {
+    for await (const chunk of llmService.stream(prompt, options)) {
+      res.write(chunk);
+    }
+    res.end();
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'LLM request failed' });
+  }
+};

--- a/src/routes/llm.js
+++ b/src/routes/llm.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const { generate } = require('../controllers/llmController');
+
+router.post('/', generate);
+
+module.exports = router;

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,12 @@
+const OpenAIService = require('./openaiService');
+
+function createLLMService() {
+  const provider = process.env.LLM_PROVIDER || 'openai';
+  switch (provider) {
+    case 'openai':
+    default:
+      return new OpenAIService(process.env.OPENAI_API_KEY);
+  }
+}
+
+module.exports = { createLLMService };

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -1,0 +1,69 @@
+class OpenAIService {
+  constructor(apiKey) {
+    this.apiKey = apiKey;
+    this.endpoint = 'https://api.openai.com/v1/chat/completions';
+  }
+
+  /**
+   * Stream completion tokens from OpenAI.
+   * Returns an async iterator yielding string chunks.
+   */
+  async *stream(prompt, options = {}) {
+    const { model = 'gpt-3.5-turbo', temperature = 0.7 } = options;
+    const response = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: 'user', content: prompt }],
+        temperature,
+        stream: true,
+      }),
+    });
+
+    if (!response.ok) {
+      const errText = await response.text();
+      throw new Error(`OpenAI API error: ${response.status} ${errText}`);
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    for await (const chunk of response.body) {
+      buffer += decoder.decode(chunk, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop();
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith('data:')) continue;
+        const data = trimmed.replace(/^data:\s*/, '');
+        if (data === '[DONE]') return;
+        try {
+          const parsed = JSON.parse(data);
+          const token = parsed.choices?.[0]?.delta?.content;
+          if (token) yield token;
+        } catch {
+          // ignore parsing errors for non-JSON lines
+        }
+      }
+    }
+  }
+
+  /**
+   * Convenience method to gather the full response by
+   * consuming the streaming iterator.
+   */
+  async generate(prompt, options = {}) {
+    let result = '';
+    for await (const chunk of this.stream(prompt, options)) {
+      result += chunk;
+    }
+    return result;
+  }
+}
+
+module.exports = OpenAIService;


### PR DESCRIPTION
## Summary
- implement OpenAI service for communicating with LLMs
- add factory to swap LLM providers via `LLM_PROVIDER`
- create controller and route for `POST /llm`
- expose the route from `app.js`
- document usage and configuration in README
- support streaming of LLM responses using OpenAI streaming API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6869fd01244c83229e150b69d7475067