### PR TITLE
Add route tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -16,6 +16,8 @@
     "express": "^4.18.2"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1"
+    "nodemon": "^3.0.1",
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3"
   }
 }

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -1,0 +1,48 @@
+const request = require('supertest');
+
+jest.mock('../src/services', () => ({
+  createLLMService: jest.fn(),
+}));
+
+const { createLLMService } = require('../src/services');
+
+function loadApp() {
+  jest.resetModules();
+  return require('../src/app');
+}
+
+describe('Health Route', () => {
+  test('GET /health returns ok', async () => {
+    const app = loadApp();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});
+
+describe('LLM Route', () => {
+  test('POST /llm streams response', async () => {
+    const mockService = {
+      stream: async function* () {
+        yield 'hello ';
+        yield 'world';
+      },
+    };
+    createLLMService.mockReturnValueOnce(mockService);
+    const app = loadApp();
+
+    const res = await request(app)
+      .post('/llm')
+      .send({ prompt: 'Hi' })
+      .expect(200)
+      .expect('Content-Type', /text\/plain/);
+
+    expect(res.text).toBe('hello world');
+  });
+
+  test('POST /llm without prompt returns 400', async () => {
+    const app = loadApp();
+    const res = await request(app).post('/llm').send({}).expect(400);
+    expect(res.body).toEqual({ error: 'Prompt is required' });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and Supertest dev dependencies
- update the `test` script
- add tests covering `/health` and `/llm`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a19d5c40c8322a1e01aeafaff1f09